### PR TITLE
Default to an empty dictionary if the observable component hasn't return anything yet

### DIFF
--- a/streamlit_observable/__init__.py
+++ b/streamlit_observable/__init__.py
@@ -56,6 +56,10 @@ def observable(key, notebook, targets=None, redefine={}, observe=[], hide=[]):
         key=key,
         name=key
     )
+    
+    if component_value is None:
+        return {}
+
     return component_value
 
 
@@ -69,4 +73,3 @@ if not _RELEASE:
     name = observers.get("name")
     
     st.write(f"Current country: ** *{name}* **")
-    


### PR DESCRIPTION
I noticed when using this that a streamlit application will show an error how I cannot call `get` of `NoneType`. I realized that initially the observable component does not return a dictionary. I think it would be best to either return an empty dictionary or specify that it could be `None`. Based on the documentation, "If the observe parameter is empty, then the dict will be empty." An empty dictionary makes the most sense.

Let me know if you have any thoughts.